### PR TITLE
Point the user-count badge at the metrics file instead of the Fly app

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Tab Keeper is an intuitive Chrome extension crafted to redefine the way users sa
 [![Static Badge](https://img.shields.io/badge/Featured_on-Chrome_Web_Store-cce7e8?style=for-the-badge)](https://chromewebstore.google.com/detail/tab-keeper-chrome-tab-man/gpibgniomobngodpnikhheifblbpbbah?ref=github)
 [![Dynamic JSON Badge](https://img.shields.io/badge/dynamic/json?url=https%3A%2F%2Fraw.githubusercontent.com%2Fjustine-george%2Ftab-keeper-react-chrome-extension%2Fmain%2Fpackage.json&query=version&style=for-the-badge&label=Version
 )](#changelog)
-![Dynamic JSON Badge](https://img.shields.io/badge/dynamic/json?url=https%3A%2F%2Fproject-metrics-flask.fly.dev%2Fextensions%2Fgpibgniomobngodpnikhheifblbpbbah%2Fusercount&query=users&style=for-the-badge&label=Users)
+![Dynamic JSON Badge](https://img.shields.io/badge/dynamic/json?url=https%3A%2F%2Fraw.githubusercontent.com%2Fjustine-george%2Fjgeorge.com%2Fmain%2Fsrc%2Fdata%2Fextension-metrics.json&query=%24.tabKeeper.users&style=for-the-badge&label=Users)
 [![Static Badge](https://img.shields.io/badge/License-MIT-blue?style=for-the-badge)](https://raw.githubusercontent.com/justine-george/tab-keeper-react-chrome-extension/main/LICENSE)
 
 <a href="https://chromewebstore.google.com/detail/tab-keeper-chrome-tab-man/gpibgniomobngodpnikhheifblbpbbah?ref=github" target="_blank"><img src="store-assets/banners/chrome_web_store_download_button.png" width="300"></a>


### PR DESCRIPTION
## Why

The Users badge in the README has been showing a **stale 2691** for months.

It reads `project-metrics-flask.fly.dev`, which scraped `chrome.google.com/webstore` — a host Google retired in 2024. The service now gets a `301` on every request, treats it as a redirect loop, and returns a hardcoded fallback. The real count is **4000**.

The badge failed invisibly: shields.io renders a perfectly normal-looking chip, so a wrong number looks exactly like a right one.

## What changed

One line. The badge now reads the count from [`jgeorge.com/src/data/extension-metrics.json`](https://github.com/justine-george/jgeorge.com/blob/main/src/data/extension-metrics.json):

```diff
-url=https%3A%2F%2Fproject-metrics-flask.fly.dev%2Fextensions%2Fgpibgniomobngodpnikhheifblbpbbah%2Fusercount&query=users
+url=https%3A%2F%2Fraw.githubusercontent.com%2Fjustine-george%2Fjgeorge.com%2Fmain%2Fsrc%2Fdata%2Fextension-metrics.json&query=%24.tabKeeper.users
```

That file is refreshed by a scheduled GitHub Action in the site repo that scrapes the current store listing and commits **only when the count actually changes**. shields.io reads any public JSON URL, so this needs no service, no auth, and nothing kept running.

## Verification

shields.io renders `USERS 4000` from the new URL. The target file is on `jgeorge.com@main` as of [#72](https://github.com/justine-george/jgeorge.com/pull/72), which is already merged — so this is safe to merge now.

## Context

This removes the last consumer of `project-metrics-flask`. Its own fix ([#1](https://github.com/justine-george/project-metrics-flask/pull/1)) merged but never deployed — the `FLY_API_TOKEN` secret is expired, so the Fly Deploy action fails with `unauthorized`. Once this merges, that service can be retired without breaking anything.

🤖 Generated with [Claude Code](https://claude.com/claude-code)